### PR TITLE
Fixed bug for ZSET in parse_object

### DIFF
--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -547,8 +547,8 @@ class RdbParser(object):
         elif enc_type == REDIS_RDB_TYPE_ZSET or enc_type == REDIS_RDB_TYPE_ZSET_2 :
             length = self.read_length(f)
             for x in range(length):
-                skip_string(f)
-                skip_binary_double(f) if enc_type == REDIS_RDB_TYPE_ZSET_2 else skip_float(f)
+                self.skip_string(f)
+                self.skip_binary_double(f) if enc_type == REDIS_RDB_TYPE_ZSET_2 else self.skip_float(f)
         elif enc_type == REDIS_RDB_TYPE_HASH :
             skip_strings = self.read_length(f) * 2
         elif enc_type == REDIS_RDB_TYPE_HASH_ZIPMAP :


### PR DESCRIPTION
First time using this tool today, and came across this issue wit 0.1.10 

```
rdb -c json --db 2 /data/redis/dump.rdb
Traceback (most recent call last):
  File "/usr/local/bin/rdb", line 9, in <module>
    load_entry_point('rdbtools==0.1.10', 'console_scripts', 'rdb')()
  File "/usr/local/lib/python2.7/dist-packages/rdbtools/cli/rdb.py", line 86, in main
    parser.parse(dump_file)
  File "/usr/local/lib/python2.7/dist-packages/rdbtools/parser.py", line 326, in parse
    self.parse_fd(open(filename, "rb"))
  File "/usr/local/lib/python2.7/dist-packages/rdbtools/parser.py", line 383, in parse_fd
    self.skip_key_and_object(f, data_type)
  File "/usr/local/lib/python2.7/dist-packages/rdbtools/parser.py", line 508, in skip_key_and_object
    self.skip_object(f, data_type)
  File "/usr/local/lib/python2.7/dist-packages/rdbtools/parser.py", line 550, in skip_object
    skip_string(f)
NameError: global name 'skip_string' is not defined
```